### PR TITLE
Remove unused class

### DIFF
--- a/app/src/main/java/org/sinisterstuf/guesstheanimal/Guesser.java
+++ b/app/src/main/java/org/sinisterstuf/guesstheanimal/Guesser.java
@@ -1,5 +1,0 @@
-package org.sinisterstuf.guesstheanimal;
-
-public class Guesser {
-	
-}


### PR DESCRIPTION
As we talked the Guesser class was meant to be user, but it was such a long time ago, that it's
better to remove from the project and re-add later if we really want to use it.