### PR TITLE
Refactor paddings in the activity xmls

### DIFF
--- a/app/src/main/res/layout/greeting.xml
+++ b/app/src/main/res/layout/greeting.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".Greeting" >
 
     <TextView

--- a/app/src/main/res/layout/guess.xml
+++ b/app/src/main/res/layout/guess.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".Guess" >
 
     <TextView

--- a/app/src/main/res/layout/learn_name.xml
+++ b/app/src/main/res/layout/learn_name.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".LearnName" >
 
     <TextView

--- a/app/src/main/res/layout/learn_question.xml
+++ b/app/src/main/res/layout/learn_question.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".LearnQuestion" >
 
     <TextView

--- a/app/src/main/res/layout/learn_yesno.xml
+++ b/app/src/main/res/layout/learn_yesno.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".LearnYesNo" >
 
     <TextView

--- a/app/src/main/res/layout/lose.xml
+++ b/app/src/main/res/layout/lose.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".Lose" >
 
     <TextView

--- a/app/src/main/res/layout/win.xml
+++ b/app/src/main/res/layout/win.xml
@@ -4,10 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:padding="@dimen/padding_default"
     tools:context=".Win" >
 
     <TextView

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,8 +1,0 @@
-<resources>
-
-    <!--
-         Customize dimensions originally defined in res/values/dimens.xml (such as
-         screen margins) for sw600dp devices (e.g. 7" tablets) here.
-    -->
-
-</resources>

--- a/app/src/main/res/values-sw720dp-land/dimens.xml
+++ b/app/src/main/res/values-sw720dp-land/dimens.xml
@@ -1,9 +1,0 @@
-<resources>
-
-    <!--
-         Customize dimensions originally defined in res/values/dimens.xml (such as
-         screen margins) for sw720dp devices (e.g. 10" tablets) in landscape here.
-    -->
-    <dimen name="activity_horizontal_margin">128dp</dimen>
-
-</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,7 +1,3 @@
 <resources>
-
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-
+    <dimen name="padding_default">16dp</dimen>
 </resources>


### PR DESCRIPTION
There is two different margin added to the dimens.xml, which have the same value and used as paddings in the activity xmls. A global android:padding can be used for setting all the padding for one ui element, so the refactor goes to this changes.

Also the project has 2 dimens.xml files for tablets, but as this project is still in a very early stage,
I think it's better to just remove those files.