### PR TITLE
Refactor activity tags in the manifest file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,9 +6,10 @@
 
     <application
         android:allowBackup="true"
+        android:allowClearUserData="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" android:allowClearUserData="true">
+        android:theme="@style/AppTheme">
         <activity
             android:name="org.sinisterstuf.guesstheanimal.Greeting"
             android:label="@string/app_name" >
@@ -18,12 +19,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="Guess" android:label="@string/app_name"></activity>
-        <activity android:name="Win" android:label="@string/app_name"></activity>
-        <activity android:name="Lose" android:label="@string/app_name"></activity>
-        <activity android:name="LearnName" android:label="@string/app_name"></activity>
-        <activity android:name="LearnQuestion" android:label="@string/app_name"></activity>
-        <activity android:name="LearnYesNo" android:label="@string/app_name"></activity>
+
+        <activity android:name="Guess"/>
+        <activity android:name="Win"/>
+        <activity android:name="Lose"/>
+        <activity android:name="LearnName"/>
+        <activity android:name="LearnQuestion"/>
+        <activity android:name="LearnYesNo"/>
+        
     </application>
 
 </manifest>


### PR DESCRIPTION
It's unnecessary to specify the app's name in every activity tag if it's already defined in the application tag. Furthermore  empty tags can be collapsed.